### PR TITLE
Added on_delete=models.CASCADE to ForeingKey

### DIFF
--- a/chapter_18/learning_logs/models.py
+++ b/chapter_18/learning_logs/models.py
@@ -11,7 +11,7 @@ class Topic(models.Model):
 
 class Entry(models.Model):
     """Something specific learned about a topic."""
-    topic = models.ForeignKey(Topic)
+    topic = models.ForeignKey(Topic, on_delete=models.CASCADE)
     text = models.TextField()
     date_added = models.DateTimeField(auto_now_add=True)
     


### PR DESCRIPTION
Since Django 2.x, on_delete is required. I suggest using .CASCADE or .DO_NOTHING so it won't show required argument error when migrating the Entry Model on page 409.

Documentation: https://docs.djangoproject.com/en/2.0/ref/models/fields/#django.db.models.ForeignKey.on_delete