### PR TITLE
docs: fix simple typo, progams -> programs

### DIFF
--- a/chapter_16/README.md
+++ b/chapter_16/README.md
@@ -28,7 +28,7 @@ The dictionary `COUNTRIES` needs to be imported from `pygal_maps_world` now:
     
 ### *world_populations.py*, *americas.py*, *na_populations.py*
 
-Pygal's world map has been moved and renamed, so these progams need an additional import statement. This update also affects one other line of code. Add the following import statement near the top of the file:
+Pygal's world map has been moved and renamed, so these programs need an additional import statement. This update also affects one other line of code. Add the following import statement near the top of the file:
 
     from pygal.maps.world import World
     


### PR DESCRIPTION
There is a small typo in chapter_16/README.md.

Should read `programs` rather than `progams`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md